### PR TITLE
Fix linking error during compilation of pid_control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ add_executable(pid_control src/freefloating_pids_main.cpp
 src/freefloating_pids.cpp include/freefloating_gazebo/freefloating_pids.h
 src/freefloating_pids_body.cpp include/freefloating_gazebo/freefloating_pids_body.h
 src/freefloating_pids_joint.cpp include/freefloating_gazebo/freefloating_pids_joint.h)
-target_link_libraries(pid_control ${catkin_LIBRARIES})
+target_link_libraries(pid_control ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(pid_control freefloating_gazebo_generate_messages_cpp)
 
 


### PR DESCRIPTION
Configuration: ROS Jade, Gazebo 6.1.0
The specific error was:
```
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::remove_sensor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::SensorManager::~SensorManager()'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::Sensor::FillMsg(gazebo::msgs::Sensor&)'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::SensorManager::SensorManager()'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::SensorManager::ResetLastUpdateTimes()'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::create_sensor(boost::shared_ptr<sdf::Element>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int)'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::SensorManager::SensorsInitialized()'
/usr/lib/libgazebo_physics.so.6: undefined reference to `gazebo::sensors::get_sensor(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
```